### PR TITLE
#5 Allow installing without setting the JAVA_HOME environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,29 @@
 
 GitHub Action to download and activate a JDK using [jabba](https://github.com/shyiko/jabba).
 
+## Quickstart
+
+~~~~yml
+steps:
+# Will download the requested distribution and by default
+#   - set the JAVA_HOME environment variable,
+#   - add the /bin folder to the PATH.
+# See Inputs for more information regarding configuration.
+- uses: battila7/jdk-via-jabba@v1
+  with:
+    jdk: graalvm@20.1.0
+
+# Thus, you can simply run:
+- run: java -version
+~~~~
+
 ## Inputs
 
 ### jdk
 
-The JDK to install and activate. You can use any expression accepted by [jabba](https://github.com/shyiko/jabba).
+  * **Required**
+
+The JDK to install. You can use any expression accepted by [jabba](https://github.com/shyiko/jabba).
 
 Examples:
 
@@ -17,15 +35,16 @@ Examples:
   * `zulu@1.8.252`
     * Version 8, update 252 of the Zulu JDK.
 
-## Usage
+### javaHomeEnvironmentVariable
 
-~~~~yml
-steps:
-- uses: actions/checkout@v2
+  * **Not Required**
+  * Default value: `JAVA_HOME`
 
-- uses: battila7/jdk-via-jabba@v1
-  with:
-    jdk: graalvm@20.1.0
+The target environment variable into which the path to the downloaded distribution will be saved.
 
-- run: java -version
-~~~~
+### addBinDirectoryToPath
+  
+  * **Not Required**
+  * Default value: `true`
+
+Whether to add the bin directory of the downloaded distribution to the PATH.

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,14 @@ inputs:
   jdk:
     description: 'The JDK to install. See https://github.com/shyiko/jabba for available expressions.'
     required: true
+  javaHomeEnvironmentVariable:
+    description: 'The target environment variable into which the path to the downloaded distribution will be saved.'
+    required: false
+    default: 'JAVA_HOME'
+  addBinDirectoryToPath:
+    description: 'Whether to add the bin directory of the downloaded distribution to the PATH.'
+    required: false
+    default: true
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/index.js
+++ b/src/index.js
@@ -7,25 +7,30 @@ const Jabba = require('./jabba')
 const log = require('./util/log')
 
 const INPUTS = {
-  jdk: 'jdk'
+  jdk: 'jdk',
+  javaHomeEnvironmentVariable: 'javaHomeEnvironmentVariable',
+  addBinDirectoryToPath: 'addBinDirectoryToPath'
 }
-
-const EXPORTS = {
-  JAVA_HOME: 'JAVA_HOME'
-};
 
 (async function main () {
   try {
     const requestedJavaDistribution = core.getInput(INPUTS.jdk)
-
     log.info(`Requested distribution is: ${requestedJavaDistribution}`)
+    
+    const javaHomeEnvironmentVariable = core.getInput(INPUTS.javaHomeEnvironmentVariable)
+    log.info(`The path to the downloaded distribution will be accessible via ${javaHomeEnvironmentVariable}`)
 
     const javaDirectory = await installJava(requestedJavaDistribution)
 
     log.info(`Local path to the distribution is: ${javaDirectory}`)
 
-    core.exportVariable(EXPORTS.JAVA_HOME, javaDirectory)
-    core.addPath(path.join(javaDirectory, 'bin'))
+    core.exportVariable(javaHomeEnvironmentVariable, javaDirectory)
+
+    if (shouldAddBinDirectoryToPath()) {
+      core.addPath(path.join(javaDirectory, 'bin'))
+
+      log.info('Exposed the bin directory of the downloaded distribution.')
+    }
   } catch (error) {
     core.setFailed(error.message)
   }
@@ -50,4 +55,10 @@ async function installJava (distribution) {
 
     return javaHome
   }
+}
+
+function shouldAddBinDirectoryToPath() {
+  const value = core.getInput(INPUTS.addBinDirectoryToPath);
+
+  return String(value).toLowerCase() == 'true'
 }

--- a/src/index.js
+++ b/src/index.js
@@ -10,13 +10,13 @@ const INPUTS = {
   jdk: 'jdk',
   javaHomeEnvironmentVariable: 'javaHomeEnvironmentVariable',
   addBinDirectoryToPath: 'addBinDirectoryToPath'
-}
+};
 
 (async function main () {
   try {
     const requestedJavaDistribution = core.getInput(INPUTS.jdk)
     log.info(`Requested distribution is: ${requestedJavaDistribution}`)
-    
+
     const javaHomeEnvironmentVariable = core.getInput(INPUTS.javaHomeEnvironmentVariable)
     log.info(`The path to the downloaded distribution will be accessible via ${javaHomeEnvironmentVariable}`)
 
@@ -57,8 +57,8 @@ async function installJava (distribution) {
   }
 }
 
-function shouldAddBinDirectoryToPath() {
-  const value = core.getInput(INPUTS.addBinDirectoryToPath);
+function shouldAddBinDirectoryToPath () {
+  const value = core.getInput(INPUTS.addBinDirectoryToPath)
 
-  return String(value).toLowerCase() == 'true'
+  return String(value).toLowerCase() === 'true'
 }


### PR DESCRIPTION
Closes #5 

Testing was performed on the [`#6-allow-installing-without-setting-the-java-home-environment-variable-test`](https://github.com/battila7/jdk-via-jabba/tree/%236-allow-installing-without-setting-the-java-home-environment-variable-test) branch.