### PR TITLE
Support multiple JDK installations

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -51,6 +51,35 @@ jobs:
         java -version
       shell: bash
 
+  use-with-custom-java-home-environment-variable:
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+    
+    - uses: "./"
+      with:
+        jdk: zulu@1.8.252
+        javaHomeEnvironmentVariable: ZULU_HOME
+
+    - uses: "./"
+      with:
+        jdk: openjdk@1.11.0
+        javaHomeEnvironmentVariable: OJ11_HOME
+
+    - name: Print Java version
+      run: |
+        echo $JAVA_HOME
+        echo $ZULU_HOME
+        echo $OJ11_HOME
+        echo $PATH
+        java -version
+      shell: bash
+
   use-without-adding-to-path:
     strategy:
       matrix:

--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -51,7 +51,7 @@ jobs:
         java -version
       shell: bash
 
-  use-with-custom-java-home-environment-variable:
+  use-2-javas-with-custom-environment-variable:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+package-lock.json
+
 node_modules
 
 # Editors

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,7 +2,7 @@ module.exports =
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 173:
+/***/ 241:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -16,7 +16,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(114);
+const utils_1 = __webpack_require__(278);
 /**
  * Commands
  *
@@ -88,7 +88,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 374:
+/***/ 186:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -110,9 +110,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __webpack_require__(173);
-const file_command_1 = __webpack_require__(579);
-const utils_1 = __webpack_require__(114);
+const command_1 = __webpack_require__(241);
+const file_command_1 = __webpack_require__(717);
+const utils_1 = __webpack_require__(278);
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
 /**
@@ -333,7 +333,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 579:
+/***/ 717:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -351,7 +351,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const fs = __importStar(__webpack_require__(747));
 const os = __importStar(__webpack_require__(87));
-const utils_1 = __webpack_require__(114);
+const utils_1 = __webpack_require__(278);
 function issueCommand(command, message) {
     const filePath = process.env[`GITHUB_${command}`];
     if (!filePath) {
@@ -369,7 +369,7 @@ exports.issueCommand = issueCommand;
 
 /***/ }),
 
-/***/ 114:
+/***/ 278:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -395,7 +395,7 @@ exports.toCommandValue = toCommandValue;
 
 /***/ }),
 
-/***/ 200:
+/***/ 514:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -417,7 +417,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const tr = __importStar(__webpack_require__(663));
+const tr = __importStar(__webpack_require__(159));
 /**
  * Exec a command.
  * Output will be streamed to the live console.
@@ -446,7 +446,7 @@ exports.exec = exec;
 
 /***/ }),
 
-/***/ 663:
+/***/ 159:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -472,8 +472,8 @@ const os = __importStar(__webpack_require__(87));
 const events = __importStar(__webpack_require__(614));
 const child = __importStar(__webpack_require__(129));
 const path = __importStar(__webpack_require__(622));
-const io = __importStar(__webpack_require__(596));
-const ioUtil = __importStar(__webpack_require__(376));
+const io = __importStar(__webpack_require__(436));
+const ioUtil = __importStar(__webpack_require__(962));
 /* eslint-disable @typescript-eslint/unbound-method */
 const IS_WINDOWS = process.platform === 'win32';
 /*
@@ -1053,16 +1053,15 @@ class ExecState extends events.EventEmitter {
 
 /***/ }),
 
-/***/ 373:
+/***/ 925:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __webpack_require__(835);
 const http = __webpack_require__(605);
 const https = __webpack_require__(211);
-const pm = __webpack_require__(583);
+const pm = __webpack_require__(443);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -1108,7 +1107,7 @@ var MediaTypes;
  * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
  */
 function getProxyUrl(serverUrl) {
-    let proxyUrl = pm.getProxyUrl(url.parse(serverUrl));
+    let proxyUrl = pm.getProxyUrl(new URL(serverUrl));
     return proxyUrl ? proxyUrl.href : '';
 }
 exports.getProxyUrl = getProxyUrl;
@@ -1127,6 +1126,15 @@ const HttpResponseRetryCodes = [
 const RetryableHttpVerbs = ['OPTIONS', 'GET', 'DELETE', 'HEAD'];
 const ExponentialBackoffCeiling = 10;
 const ExponentialBackoffTimeSlice = 5;
+class HttpClientError extends Error {
+    constructor(message, statusCode) {
+        super(message);
+        this.name = 'HttpClientError';
+        this.statusCode = statusCode;
+        Object.setPrototypeOf(this, HttpClientError.prototype);
+    }
+}
+exports.HttpClientError = HttpClientError;
 class HttpClientResponse {
     constructor(message) {
         this.message = message;
@@ -1145,7 +1153,7 @@ class HttpClientResponse {
 }
 exports.HttpClientResponse = HttpClientResponse;
 function isHttps(requestUrl) {
-    let parsedUrl = url.parse(requestUrl);
+    let parsedUrl = new URL(requestUrl);
     return parsedUrl.protocol === 'https:';
 }
 exports.isHttps = isHttps;
@@ -1250,7 +1258,7 @@ class HttpClient {
         if (this._disposed) {
             throw new Error('Client has already been disposed.');
         }
-        let parsedUrl = url.parse(requestUrl);
+        let parsedUrl = new URL(requestUrl);
         let info = this._prepareRequest(verb, parsedUrl, headers);
         // Only perform retries on reads since writes may not be idempotent.
         let maxTries = this._allowRetries && RetryableHttpVerbs.indexOf(verb) != -1
@@ -1289,7 +1297,7 @@ class HttpClient {
                     // if there's no location to redirect to, we won't
                     break;
                 }
-                let parsedRedirectUrl = url.parse(redirectUrl);
+                let parsedRedirectUrl = new URL(redirectUrl);
                 if (parsedUrl.protocol == 'https:' &&
                     parsedUrl.protocol != parsedRedirectUrl.protocol &&
                     !this._allowRedirectDowngrade) {
@@ -1405,7 +1413,7 @@ class HttpClient {
      * @param serverUrl  The server URL where the request will be sent. For example, https://api.github.com
      */
     getAgent(serverUrl) {
-        let parsedUrl = url.parse(serverUrl);
+        let parsedUrl = new URL(serverUrl);
         return this._getAgent(parsedUrl);
     }
     _prepareRequest(method, requestUrl, headers) {
@@ -1472,13 +1480,15 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __webpack_require__(419);
+                tunnel = __webpack_require__(294);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
                 keepAlive: this._keepAlive,
                 proxy: {
-                    proxyAuth: proxyUrl.auth,
+                    ...((proxyUrl.username || proxyUrl.password) && {
+                        proxyAuth: `${proxyUrl.username}:${proxyUrl.password}`
+                    }),
                     host: proxyUrl.hostname,
                     port: proxyUrl.port
                 }
@@ -1573,12 +1583,8 @@ class HttpClient {
                 else {
                     msg = 'Failed request: (' + statusCode + ')';
                 }
-                let err = new Error(msg);
-                // attach statusCode and body obj (if available) to the error object
-                err['statusCode'] = statusCode;
-                if (response.result) {
-                    err['result'] = response.result;
-                }
+                let err = new HttpClientError(msg, statusCode);
+                err.result = response.result;
                 reject(err);
             }
             else {
@@ -1592,13 +1598,12 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 583:
-/***/ ((__unused_webpack_module, exports, __webpack_require__) => {
+/***/ 443:
+/***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const url = __webpack_require__(835);
 function getProxyUrl(reqUrl) {
     let usingSsl = reqUrl.protocol === 'https:';
     let proxyUrl;
@@ -1613,7 +1618,7 @@ function getProxyUrl(reqUrl) {
         proxyVar = process.env['http_proxy'] || process.env['HTTP_PROXY'];
     }
     if (proxyVar) {
-        proxyUrl = url.parse(proxyVar);
+        proxyUrl = new URL(proxyVar);
     }
     return proxyUrl;
 }
@@ -1658,7 +1663,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 376:
+/***/ 962:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -1672,11 +1677,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 var _a;
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const assert_1 = __webpack_require__(357);
-const fs = __webpack_require__(747);
-const path = __webpack_require__(622);
+const fs = __importStar(__webpack_require__(747));
+const path = __importStar(__webpack_require__(622));
 _a = fs.promises, exports.chmod = _a.chmod, exports.copyFile = _a.copyFile, exports.lstat = _a.lstat, exports.mkdir = _a.mkdir, exports.readdir = _a.readdir, exports.readlink = _a.readlink, exports.rename = _a.rename, exports.rmdir = _a.rmdir, exports.stat = _a.stat, exports.symlink = _a.symlink, exports.unlink = _a.unlink;
 exports.IS_WINDOWS = process.platform === 'win32';
 function exists(fsPath) {
@@ -1860,7 +1872,7 @@ function isUnixExecutable(stats) {
 
 /***/ }),
 
-/***/ 596:
+/***/ 436:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -1874,11 +1886,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const childProcess = __webpack_require__(129);
-const path = __webpack_require__(622);
+const childProcess = __importStar(__webpack_require__(129));
+const path = __importStar(__webpack_require__(622));
 const util_1 = __webpack_require__(669);
-const ioUtil = __webpack_require__(376);
+const ioUtil = __importStar(__webpack_require__(962));
 const exec = util_1.promisify(childProcess.exec);
 /**
  * Copies a file or folder.
@@ -2046,58 +2065,73 @@ function which(tool, check) {
                     throw new Error(`Unable to locate executable file: ${tool}. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.`);
                 }
             }
+            return result;
         }
-        try {
-            // build the list of extensions to try
-            const extensions = [];
-            if (ioUtil.IS_WINDOWS && process.env.PATHEXT) {
-                for (const extension of process.env.PATHEXT.split(path.delimiter)) {
-                    if (extension) {
-                        extensions.push(extension);
-                    }
-                }
-            }
-            // if it's rooted, return it if exists. otherwise return empty.
-            if (ioUtil.isRooted(tool)) {
-                const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
-                if (filePath) {
-                    return filePath;
-                }
-                return '';
-            }
-            // if any path separators, return empty
-            if (tool.includes('/') || (ioUtil.IS_WINDOWS && tool.includes('\\'))) {
-                return '';
-            }
-            // build the list of directories
-            //
-            // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
-            // it feels like we should not do this. Checking the current directory seems like more of a use
-            // case of a shell, and the which() function exposed by the toolkit should strive for consistency
-            // across platforms.
-            const directories = [];
-            if (process.env.PATH) {
-                for (const p of process.env.PATH.split(path.delimiter)) {
-                    if (p) {
-                        directories.push(p);
-                    }
-                }
-            }
-            // return the first match
-            for (const directory of directories) {
-                const filePath = yield ioUtil.tryGetExecutablePath(directory + path.sep + tool, extensions);
-                if (filePath) {
-                    return filePath;
-                }
-            }
-            return '';
+        const matches = yield findInPath(tool);
+        if (matches && matches.length > 0) {
+            return matches[0];
         }
-        catch (err) {
-            throw new Error(`which failed with message ${err.message}`);
-        }
+        return '';
     });
 }
 exports.which = which;
+/**
+ * Returns a list of all occurrences of the given tool on the system path.
+ *
+ * @returns   Promise<string[]>  the paths of the tool
+ */
+function findInPath(tool) {
+    return __awaiter(this, void 0, void 0, function* () {
+        if (!tool) {
+            throw new Error("parameter 'tool' is required");
+        }
+        // build the list of extensions to try
+        const extensions = [];
+        if (ioUtil.IS_WINDOWS && process.env['PATHEXT']) {
+            for (const extension of process.env['PATHEXT'].split(path.delimiter)) {
+                if (extension) {
+                    extensions.push(extension);
+                }
+            }
+        }
+        // if it's rooted, return it if exists. otherwise return empty.
+        if (ioUtil.isRooted(tool)) {
+            const filePath = yield ioUtil.tryGetExecutablePath(tool, extensions);
+            if (filePath) {
+                return [filePath];
+            }
+            return [];
+        }
+        // if any path separators, return empty
+        if (tool.includes(path.sep)) {
+            return [];
+        }
+        // build the list of directories
+        //
+        // Note, technically "where" checks the current directory on Windows. From a toolkit perspective,
+        // it feels like we should not do this. Checking the current directory seems like more of a use
+        // case of a shell, and the which() function exposed by the toolkit should strive for consistency
+        // across platforms.
+        const directories = [];
+        if (process.env.PATH) {
+            for (const p of process.env.PATH.split(path.delimiter)) {
+                if (p) {
+                    directories.push(p);
+                }
+            }
+        }
+        // find all matches
+        const matches = [];
+        for (const directory of directories) {
+            const filePath = yield ioUtil.tryGetExecutablePath(path.join(directory, tool), extensions);
+            if (filePath) {
+                matches.push(filePath);
+            }
+        }
+        return matches;
+    });
+}
+exports.findInPath = findInPath;
 function readCopyOptions(options) {
     const force = options.force == null ? true : options.force;
     const recursive = Boolean(options.recursive);
@@ -2157,7 +2191,7 @@ function copyFile(srcFile, destFile, force) {
 
 /***/ }),
 
-/***/ 942:
+/***/ 473:
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
@@ -2179,8 +2213,8 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const semver = __importStar(__webpack_require__(991));
-const core_1 = __webpack_require__(374);
+const semver = __importStar(__webpack_require__(911));
+const core_1 = __webpack_require__(186);
 // needs to be require for core node modules to be mocked
 /* eslint @typescript-eslint/no-require-imports: 0 */
 const os = __webpack_require__(87);
@@ -2270,7 +2304,7 @@ exports._readLinuxVersionFile = _readLinuxVersionFile;
 
 /***/ }),
 
-/***/ 841:
+/***/ 279:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -2292,7 +2326,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(374));
+const core = __importStar(__webpack_require__(186));
 /**
  * Internal class for retries
  */
@@ -2347,7 +2381,7 @@ exports.RetryHelper = RetryHelper;
 
 /***/ }),
 
-/***/ 774:
+/***/ 784:
 /***/ (function(__unused_webpack_module, exports, __webpack_require__) {
 
 "use strict";
@@ -2372,20 +2406,20 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const core = __importStar(__webpack_require__(374));
-const io = __importStar(__webpack_require__(596));
+const core = __importStar(__webpack_require__(186));
+const io = __importStar(__webpack_require__(436));
 const fs = __importStar(__webpack_require__(747));
-const mm = __importStar(__webpack_require__(942));
+const mm = __importStar(__webpack_require__(473));
 const os = __importStar(__webpack_require__(87));
 const path = __importStar(__webpack_require__(622));
-const httpm = __importStar(__webpack_require__(373));
-const semver = __importStar(__webpack_require__(991));
+const httpm = __importStar(__webpack_require__(925));
+const semver = __importStar(__webpack_require__(911));
 const stream = __importStar(__webpack_require__(413));
 const util = __importStar(__webpack_require__(669));
-const v4_1 = __importDefault(__webpack_require__(145));
-const exec_1 = __webpack_require__(200);
+const v4_1 = __importDefault(__webpack_require__(824));
+const exec_1 = __webpack_require__(514);
 const assert_1 = __webpack_require__(357);
-const retry_helper_1 = __webpack_require__(841);
+const retry_helper_1 = __webpack_require__(279);
 class HTTPError extends Error {
     constructor(httpStatusCode) {
         super(`Unexpected HTTP response: ${httpStatusCode}`);
@@ -2960,7 +2994,7 @@ function _unique(values) {
 
 /***/ }),
 
-/***/ 991:
+/***/ 911:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -4563,15 +4597,15 @@ function coerce (version, options) {
 
 /***/ }),
 
-/***/ 419:
+/***/ 294:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-module.exports = __webpack_require__(797);
+module.exports = __webpack_require__(219);
 
 
 /***/ }),
 
-/***/ 797:
+/***/ 219:
 /***/ ((__unused_webpack_module, exports, __webpack_require__) => {
 
 "use strict";
@@ -4843,7 +4877,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 505:
+/***/ 707:
 /***/ ((module) => {
 
 /**
@@ -4876,7 +4910,7 @@ module.exports = bytesToUuid;
 
 /***/ }),
 
-/***/ 497:
+/***/ 859:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 // Unique ID creation requires a high quality random # generator.  In node.js
@@ -4891,11 +4925,11 @@ module.exports = function nodeRNG() {
 
 /***/ }),
 
-/***/ 145:
+/***/ 824:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-var rng = __webpack_require__(497);
-var bytesToUuid = __webpack_require__(505);
+var rng = __webpack_require__(859);
+var bytesToUuid = __webpack_require__(707);
 
 function v4(options, buf, offset) {
   var i = buf && offset || 0;
@@ -4927,16 +4961,16 @@ module.exports = v4;
 
 /***/ }),
 
-/***/ 800:
+/***/ 351:
 /***/ ((__unused_webpack_module, __unused_webpack_exports, __webpack_require__) => {
 
 const path = __webpack_require__(622)
 
-const core = __webpack_require__(374)
-const cache = __webpack_require__(774)
+const core = __webpack_require__(186)
+const cache = __webpack_require__(784)
 
-const Jabba = __webpack_require__(647)
-const log = __webpack_require__(744)
+const Jabba = __webpack_require__(635)
+const log = __webpack_require__(48)
 
 const INPUTS = {
   jdk: 'jdk',
@@ -4998,23 +5032,23 @@ function shouldAddBinDirectoryToPath () {
 
 /***/ }),
 
-/***/ 647:
+/***/ 635:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 const path = __webpack_require__(622)
 
-const cache = __webpack_require__(774)
+const cache = __webpack_require__(784)
 
-const exec = __webpack_require__(824)
-const log = __webpack_require__(744)
+const exec = __webpack_require__(791)
+const log = __webpack_require__(48)
 
 const platformDependentImpl = (function chooseImpl () {
   if (process.platform === 'win32') {
-    return __webpack_require__(941)
+    return __webpack_require__(542)
   } else if (process.platform === 'darwin') {
-    return __webpack_require__(100)
+    return __webpack_require__(64)
   } else {
-    return __webpack_require__(537)
+    return __webpack_require__(220)
   }
 })()
 
@@ -5039,7 +5073,7 @@ const Jabba = {
 
     log.info(`Installed distribution: ${distributionExpression}`)
 
-    const javaHome = this.actualHomeDirectory(await this.getPathToJava())
+    const javaHome = this.actualHomeDirectory(await this.getPathToJava(distributionExpression))
 
     return javaHome
   },
@@ -5048,8 +5082,9 @@ const Jabba = {
     await this.runJabba('install', [distributionExpression])
   },
 
-  async getPathToJava () {
-    const distributionName = await this.runJabba('ls')
+  async getPathToJava (distributionExpression) {
+    log.info(`Listing distribution: ${distributionExpression}`)
+    const distributionName = await this.runJabba('ls', [distributionExpression])
 
     log.info(`Local name of distribution is: ${distributionName}`)
 
@@ -5074,7 +5109,7 @@ module.exports = Jabba
 
 /***/ }),
 
-/***/ 100:
+/***/ 64:
 /***/ ((module) => {
 
 async function installJabba () {
@@ -5104,7 +5139,7 @@ module.exports = macosImpl
 
 /***/ }),
 
-/***/ 537:
+/***/ 220:
 /***/ ((module) => {
 
 async function installJabba () {
@@ -5134,12 +5169,12 @@ module.exports = nixImpl
 
 /***/ }),
 
-/***/ 941:
+/***/ 542:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
 const { spawnSync } = __webpack_require__(129)
 
-const log = __webpack_require__(744)
+const log = __webpack_require__(48)
 
 async function installJabba () {
   const scriptPath = this._deps.path.join(__dirname, '..', 'install-jabba.ps1')
@@ -5174,10 +5209,10 @@ module.exports = windowsImpl
 
 /***/ }),
 
-/***/ 824:
+/***/ 791:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-const actionsExec = __webpack_require__(200)
+const actionsExec = __webpack_require__(514)
 
 async function exec (command, args, options) {
   return await actionsExec.exec(command, args, options)
@@ -5207,10 +5242,10 @@ module.exports = {
 
 /***/ }),
 
-/***/ 744:
+/***/ 48:
 /***/ ((module, __unused_webpack_exports, __webpack_require__) => {
 
-const core = __webpack_require__(374)
+const core = __webpack_require__(186)
 
 const log = {
   debug (message) {
@@ -5328,14 +5363,6 @@ module.exports = require("tls");
 
 /***/ }),
 
-/***/ 835:
-/***/ ((module) => {
-
-"use strict";
-module.exports = require("url");
-
-/***/ }),
-
 /***/ 669:
 /***/ ((module) => {
 
@@ -5382,6 +5409,6 @@ module.exports = require("util");
 /******/ 	// module exports must be returned from runtime so entry inlining is disabled
 /******/ 	// startup
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(800);
+/******/ 	return __webpack_require__(351);
 /******/ })()
 ;

--- a/src/jabba/index.js
+++ b/src/jabba/index.js
@@ -36,7 +36,7 @@ const Jabba = {
 
     log.info(`Installed distribution: ${distributionExpression}`)
 
-    const javaHome = this.actualHomeDirectory(await this.getPathToJava())
+    const javaHome = this.actualHomeDirectory(await this.getPathToJava(distributionExpression))
 
     return javaHome
   },
@@ -45,8 +45,8 @@ const Jabba = {
     await this.runJabba('install', [distributionExpression])
   },
 
-  async getPathToJava () {
-    const distributionName = await this.runJabba('ls')
+  async getPathToJava (distributionExpression) {
+    const distributionName = await this.runJabba('ls', [distributionExpression])
 
     log.info(`Local name of distribution is: ${distributionName}`)
 

--- a/src/jabba/index.js
+++ b/src/jabba/index.js
@@ -46,6 +46,7 @@ const Jabba = {
   },
 
   async getPathToJava (distributionExpression) {
+    log.info(`Listing distribution: ${distributionExpression}`)
     const distributionName = await this.runJabba('ls', [distributionExpression])
 
     log.info(`Local name of distribution is: ${distributionName}`)


### PR DESCRIPTION
I'd like to install multiple JDKs so I can create a fairly complex Maven toolchains.xml file for use in my build process. However, the current `jabba ls` call when retrieving the java home after installing the new JDK doesn't include the target distribution expression, which means it will return the full listing of installed JDKs. This list (with line breaks) is then passed, unprocessed, into the `jabba which` call, and causes a failure.

The new code will pass the target distributionExpression into the java home logic, so the `ls` call can include it and avoid returning results from other JDKs that were installed in other steps.